### PR TITLE
Codify the branch/preview/data-context workflow and enforce no-commit-to-main

### DIFF
--- a/.claude/hooks/block-main-commit.sh
+++ b/.claude/hooks/block-main-commit.sh
@@ -4,17 +4,30 @@
 # Policy lives in CLAUDE.md: feature branch -> PR -> review -> merge.
 set -uo pipefail
 
-cmd=$(jq -r '.tool_input.command // ""')
-
-# Only intervene on commands that actually reach `git commit`, including
-# compound forms like `git add -A && git commit -m "..."` and `git -C dir commit`.
-if ! printf '%s' "$cmd" | grep -Eq '(^|[^[:alnum:]_./-])git([[:space:]]+[^;&|[:space:]]+)*[[:space:]]+commit([^[:alnum:]_-]|$)'; then
+# Fail open rather than breaking every Bash call, but say so — a policy hook
+# that silently stops enforcing is worse than one that is obviously off.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "block-main-commit: jq not found; branch policy NOT enforced" >&2
   exit 0
 fi
 
-# A command that switches branch before it commits is exactly the right thing to
-# do, so let it through (e.g. `git switch -c rk/foo && git commit -m "..."`).
-if printf '%s' "${cmd%%commit*}" | grep -Eq 'git[[:space:]]+(switch|checkout|worktree)\b'; then
+cmd=$(jq -r '.tool_input.command // ""')
+
+# Only intervene when `commit` is the actual git subcommand — i.e. the first
+# token after `git` and any global options (`-C <path>`, `-c <cfg>`, `--no-pager`).
+# Anchoring this way still catches compound forms (`git add -A && git commit …`)
+# without snagging commands that merely mention the word (`git help commit`).
+commit_re='(^|[^[:alnum:]_./-])git([[:space:]]+(-[cC][[:space:]]+[^;&|[:space:]]+|--[^;&|[:space:]]+|-[^-;&|[:space:]]+))*[[:space:]]+commit([^[:alnum:]_-]|$)'
+if ! printf '%s' "$cmd" | grep -Eq "$commit_re"; then
+  exit 0
+fi
+
+# A command that *creates* a branch before committing is exactly the right thing
+# to do, so let it through (e.g. `git switch -c rk/foo && git commit -m "..."`).
+# Deliberately narrow: a bare `git switch main && git commit` must still be
+# blocked, so plain switches/checkouts do not count as an escape hatch.
+create_re='git[[:space:]]+(switch[[:space:]]+-[cC]|checkout[[:space:]]+-[bB]|worktree[[:space:]]+add)([^[:alnum:]_-]|$)'
+if printf '%s' "${cmd%%commit*}" | grep -Eq "$create_re"; then
   exit 0
 fi
 

--- a/.claude/hooks/block-main-commit.sh
+++ b/.claude/hooks/block-main-commit.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Blocks `git commit` while HEAD is on main/master.
+# Wired up as a PreToolUse hook on Bash in .claude/settings.json.
+# Policy lives in CLAUDE.md: feature branch -> PR -> review -> merge.
+set -uo pipefail
+
+cmd=$(jq -r '.tool_input.command // ""')
+
+# Only intervene on commands that actually reach `git commit`, including
+# compound forms like `git add -A && git commit -m "..."` and `git -C dir commit`.
+if ! printf '%s' "$cmd" | grep -Eq '(^|[^[:alnum:]_./-])git([[:space:]]+[^;&|[:space:]]+)*[[:space:]]+commit([^[:alnum:]_-]|$)'; then
+  exit 0
+fi
+
+# A command that switches branch before it commits is exactly the right thing to
+# do, so let it through (e.g. `git switch -c rk/foo && git commit -m "..."`).
+if printf '%s' "${cmd%%commit*}" | grep -Eq 'git[[:space:]]+(switch|checkout|worktree)\b'; then
+  exit 0
+fi
+
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+case "$branch" in
+  main | master) ;;
+  *) exit 0 ;;
+esac
+
+jq -n --arg b "$branch" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: ("Refusing to commit directly to \($b) — this repo requires feature branch -> PR -> review -> merge (see CLAUDE.md). Create a branch first (`git switch -c <slug>`), then commit there. The /ship-pr skill does the whole loop.")
+  }
+}'

--- a/.claude/hooks/test-block-main-commit.sh
+++ b/.claude/hooks/test-block-main-commit.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Allow/block matrix for block-main-commit.sh. Run directly: .claude/hooks/test-block-main-commit.sh
+# Builds a throwaway repo on `main` so the branch check actually engages, then
+# again on a feature branch to confirm the hook stays out of the way there.
+set -uo pipefail
+
+hook="$(cd "$(dirname "$0")" && pwd)/block-main-commit.sh"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+git init -q -b main "$tmp"
+git -C "$tmp" commit -q --allow-empty -m init
+
+fails=0
+
+# verdict <command> -> prints BLOCKED or allowed
+verdict() {
+  local out
+  out=$(printf '{"tool_input":{"command":%s}}' "$(jq -Rn --arg c "$1" '$c')" | (cd "$tmp" && "$hook"))
+  [ -n "$out" ] && echo BLOCKED || echo allowed
+}
+
+check() {
+  local want=$1 cmd=$2 got
+  got=$(verdict "$cmd")
+  if [ "$got" = "$want" ]; then
+    printf '  ok   %-52s %s\n' "$cmd" "$got"
+  else
+    printf '  FAIL %-52s want %s, got %s\n' "$cmd" "$want" "$got"
+    fails=$((fails + 1))
+  fi
+}
+
+echo "on main — commits must be blocked:"
+check BLOCKED 'git commit -m x'
+check BLOCKED 'git commit --amend --no-edit'
+check BLOCKED 'git add -A && git commit -m "x"'
+check BLOCKED 'cd docs && git commit -m x'
+check BLOCKED 'git -C /some/dir commit --amend'
+check BLOCKED 'git --no-pager commit -m x'
+# Switching *onto* main is not an escape hatch.
+check BLOCKED 'git switch main && git commit -m x'
+check BLOCKED 'git checkout main && git commit -m x'
+check BLOCKED 'git worktree list && git commit -m x'
+
+echo "on main — creating a branch first is the sanctioned path:"
+check allowed 'git switch -c rk/foo && git commit -m x'
+check allowed 'git checkout -b rk/bar; git commit -m x'
+check allowed 'git worktree add ../wt -b rk/baz && git commit -m x'
+
+echo "on main — non-commit commands must pass untouched:"
+check allowed 'git status'
+check allowed 'git help commit'
+check allowed 'git config --global commit.gpgsign false'
+check allowed 'git log --grep commit'
+check allowed 'git log --oneline | grep commit'
+check allowed 'gh pr merge 12'
+check allowed 'quarto render posts/foo/index.qmd'
+
+echo "on a feature branch — the hook must not fire at all:"
+git -C "$tmp" checkout -q -b rk/feature
+check allowed 'git commit -m x'
+check allowed 'git add -A && git commit -m "x"'
+
+if [ "$fails" -eq 0 ]; then
+  echo "PASS"
+else
+  echo "FAIL: $fails case(s)"
+  exit 1
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-main-commit.sh\"",
+            "timeout": 10,
+            "statusMessage": "Checking branch policy..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ A personal ML/data blog ("Synthetic Musings") built with [Quarto](https://quarto
 
 **Never commit to `main`.** Every change — new post, edit, fix, even a one-line typo — goes through: feature branch → commit (source *and* the re-rendered `docs/` output together) → push → open a PR with a real description of what changed and why → PR review → merge. `main` only ever advances via a merged PR. The `ship-pr` skill automates this loop.
 
-This is enforced, not just documented: `.claude/settings.json` registers a `PreToolUse` hook on `Bash` that runs `.claude/hooks/block-main-commit.sh`, which denies any command reaching `git commit` while HEAD is on `main`/`master`. A command that switches branch first (`git switch -c rk/foo && git commit …`) passes. To override deliberately, commit from your own terminal, or disable the hook via `/hooks`.
+This is enforced, not just documented: `.claude/settings.json` registers a `PreToolUse` hook on `Bash` that runs `.claude/hooks/block-main-commit.sh`, which denies any command reaching `git commit` while HEAD is on `main`/`master`. A command that *creates* a branch first passes (`git switch -c rk/foo && git commit …`); a bare `git switch main && git commit` does not — switching onto `main` is not an escape hatch. Switching to an *existing* branch and committing is also blocked while on `main`, which is deliberate: it fails safe, and the deny message says what to do. Run `.claude/hooks/test-block-main-commit.sh` after touching the hook — it asserts the full allow/block matrix. To override deliberately, commit from your own terminal, or disable the hook via `/hooks`.
 
 **Hand back a localhost preview link whenever a unit of work is complete.** Don't just say "done" — give a clickable URL the change can be eyeballed at, e.g.:
 
@@ -30,8 +30,8 @@ Prefer the single-post form; a whole-project preview indexes and executes every 
 **Kill every running Quarto preview server once the change is shipped and merged.** After the PR merges, tear the servers down so stale previews don't linger on their ports:
 
 ```bash
-pkill -f "quarto preview" ; pkill -f "quarto.*preview"   # quarto preview servers
-pkill -f "http.server .*docs"                             # any static docs server started for previewing
+pkill -f "quarto.*preview"        # quarto preview servers
+pkill -f "http.server .*docs"     # any static docs server started for previewing
 ```
 
 Confirm nothing survives (`pgrep -fl "quarto preview"` should print nothing) and say so in the wrap-up.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-A personal ML/data blog ("Synthetic Musings") built with [Quarto](https://quarto.org/) and published to GitHub Pages at https://project-delphi.github.io/ml-blog/. Each post is a self-contained `.qmd` or `.ipynb` file under `posts/<slug>/`; the rendered static site lives in `docs/` and is committed directly to `main` (there is no CI workflow — `docs/` must be rendered and committed locally as part of any content change).
+A personal ML/data blog ("Synthetic Musings") built with [Quarto](https://quarto.org/) and published to GitHub Pages at https://project-delphi.github.io/ml-blog/. Each post is a self-contained `.qmd` or `.ipynb` file under `posts/<slug>/`; the rendered static site lives in `docs/` and is served from `main` (there is no CI workflow — `docs/` must be rendered locally and committed *in the same commit/PR* as the source change, otherwise the published site drifts from the source).
 
 ## Commands
 
@@ -13,6 +13,40 @@ A personal ML/data blog ("Synthetic Musings") built with [Quarto](https://quarto
 - Preview: `quarto preview` (or `make preview`). Previewing the whole project also indexes/executes every post the first time, so prefer `quarto preview posts/<slug>/index.qmd` or serve the already-built `docs/` folder statically (e.g. `python -m http.server` from `docs/`) when you just need to eyeball one post.
 - `make venv` / `make install`: create `.venv` and `pip install .` (the base dev/lint toolchain from `pyproject.toml` — this does *not* include per-post ML dependencies, see below).
 - Lint/format tooling (black, ruff, mypy, pyupgrade, commitizen, codespell) is configured in `.pre-commit-config.yaml` and `pyproject.toml` (`[tool.ruff]`, `[tool.pydoclint]`, `[tool.codespell]`) but hooks aren't installed by default — run manually with `pre-commit run --all-files` if needed.
+
+## Workflow
+
+**Never commit to `main`.** Every change — new post, edit, fix, even a one-line typo — goes through: feature branch → commit (source *and* the re-rendered `docs/` output together) → push → open a PR with a real description of what changed and why → PR review → merge. `main` only ever advances via a merged PR. The `ship-pr` skill automates this loop.
+
+This is enforced, not just documented: `.claude/settings.json` registers a `PreToolUse` hook on `Bash` that runs `.claude/hooks/block-main-commit.sh`, which denies any command reaching `git commit` while HEAD is on `main`/`master`. A command that switches branch first (`git switch -c rk/foo && git commit …`) passes. To override deliberately, commit from your own terminal, or disable the hook via `/hooks`.
+
+**Hand back a localhost preview link whenever a unit of work is complete.** Don't just say "done" — give a clickable URL the change can be eyeballed at, e.g.:
+
+- `quarto preview posts/<slug>/index.qmd` and report the URL it prints (typically `http://localhost:<port>/`), or
+- serve the already-built output: `python -m http.server 8000 --directory docs` → `http://localhost:8000/posts/<slug>/index.html`.
+
+Prefer the single-post form; a whole-project preview indexes and executes every post.
+
+**Kill every running Quarto preview server once the change is shipped and merged.** After the PR merges, tear the servers down so stale previews don't linger on their ports:
+
+```bash
+pkill -f "quarto preview" ; pkill -f "quarto.*preview"   # quarto preview servers
+pkill -f "http.server .*docs"                             # any static docs server started for previewing
+```
+
+Confirm nothing survives (`pgrep -fl "quarto preview"` should print nothing) and say so in the wrap-up.
+
+## Writing conventions
+
+**Always situate the data.** Any post that uses, plots, or even mentions a dataset must tell the reader where it came from before doing anything with it. Cover, in prose (not a bullet checklist bolted on):
+
+- **Provenance** — what the dataset actually is, and a link/citation to the source.
+- **Collector and motive** — who gathered it, under what program or institution, and why they went to the trouble. Instrument, survey, scrape, simulation: say which.
+- **Objective** — what question is being asked *of this data in this post*, and what the target/label means in the real world.
+- **Downstream impact** — what a decision made from this analysis would actually affect (a diagnosis, a loan, a forecast, a research conclusion), and what it costs to be wrong.
+- **Why this method** — what specific property of *this* data (sample size, noise, class imbalance, heavy tails, hierarchy, missingness, small-n uncertainty) makes the technique in the post the right tool, and which quantity we care about it improves.
+
+Synthetic data is not exempt: state that it is synthetic, give the generating process, and explain what real-world situation it is standing in for and why simulating is preferable to a real dataset here.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

Three standing expectations existed only as habit. This writes them into `CLAUDE.md` and, for the one that actually has teeth, enforces it in the harness.

- **Never commit to `main`.** Documented as branch → commit → push → PR → review → merge, and backed by a `PreToolUse` hook on `Bash` (`.claude/hooks/block-main-commit.sh`) that denies any command reaching `git commit` while HEAD is on `main`/`master`. Previously nothing caught a stray commit.
- **Hand back a localhost preview link** when a unit of work is complete, and **kill Quarto preview servers once it merges** so stale previews don't hold ports.
- **Situate the data** in any post that touches a dataset: provenance, who collected it and why, the objective, downstream impact and cost of being wrong, and what property of the data makes the post's method the right tool. Synthetic data isn't exempt.

Also corrects a line in `## What this is` that said `docs/` is "committed directly to `main`" — now contradicted by the branch rule. It reads as served from `main`, rendered locally and committed in the same PR as the source.

### Design notes

- The hook matches **compound** commands (`cd docs && git commit …`), not just ones starting with `git`. An `if: "Bash(git *)"` filter was tried and dropped because it prefix-matches and would have let those through.
- Commands that **switch branch first** (`git switch -c rk/foo && git commit …`) are deliberately allowed — that is the correct move, so blocking it would be self-defeating.

## Test plan

- [x] Pipe-tested the script against blocked cases: `git commit -m x`, `git add -A && git commit -m x`, `git commit --amend --no-edit`, `git -C /dir commit`
- [x] Pipe-tested allowed cases: `git switch -c rk/foo && git commit -m y`, `git checkout -b rk/bar; git commit -m y`, `git status`, `gh pr merge 12`, `quarto render …`
- [x] Verified live on `main`: `git commit --allow-empty` was denied with the policy message, `git log -1` confirmed HEAD unchanged and no commit created
- [x] Verified the hook does *not* fire on a feature branch — the commit in this PR went through normally
- [x] `jq -e` validates the `settings.json` hook structure
- [ ] Not tested: hook loading in a fresh session (`.claude/` did not exist as a settings dir when this session started, so the config watcher may need `/hooks` or a restart to pick it up on first clone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)