### PR TITLE
fix(claude): catch docs servers started with cd instead of --directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,10 +29,15 @@ This is enforced: `.claude/settings.json` registers a `PreToolUse` hook on `Bash
 
 ```bash
 pkill -f "quarto.*preview"        # quarto preview servers
-pkill -f "http.server .*docs"     # any static docs server started for previewing
+# Static docs servers. Matching argv misses `cd docs && python -m http.server`
+# (no "docs" in its command line), so match on cwd — which also spares servers
+# belonging to other projects. Run from the repo root.
+pgrep -f "http\.server" | while read -r pid; do
+  lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | grep -q "^n$PWD" && kill "$pid"
+done
 ```
 
-Confirm nothing survives (`pgrep -fl "quarto preview"` should print nothing) and say so in the wrap-up.
+Confirm nothing survives — `pgrep -fl "quarto preview"` prints nothing, and `lsof -nP -iTCP -sTCP:LISTEN | grep -i python` lists no server rooted in this repo — and say so in the wrap-up.
 
 ## Writing conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,8 @@ pkill -f "quarto.*preview"        # quarto preview servers
 # (no "docs" in its command line), so match on cwd — which also spares servers
 # belonging to other projects. Run from the repo root.
 pgrep -f "http\.server" | while read -r pid; do
-  lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | grep -q "^n$PWD" && kill "$pid"
+  cwd=$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p')
+  case "$cwd" in "$PWD"|"$PWD"/*) kill "$pid";; esac
 done
 ```
 


### PR DESCRIPTION
## Summary

The documented preview teardown had a blind spot that let a stale server survive — and it bit for real this session.

`pkill -f "http.server .*docs"` only matches servers started as `python -m http.server --directory docs`. A server started the other common way:

```bash
cd docs && python -m http.server 8899
```

has **no `docs` anywhere in its command line**, so the pattern never matched it. It sat on port 8899 through several merges, and I initially misreported it as belonging to another project on exactly that basis.

The fix matches on **working directory** instead of argv, which catches both forms and — as a bonus — is narrower where it matters: it deliberately spares `http.server` processes rooted outside this repo, which a broader `pkill -f "http.server"` would have killed.

```bash
pgrep -f "http\.server" | while read -r pid; do
  lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | grep -q "^n$PWD" && kill "$pid"
done
```

The confirmation step is extended to match, since `pgrep -fl "quarto preview"` alone never covered the static-server case.

## Test plan

Tested against the exact case that slipped through, with a real server started the `cd docs` way:

- [x] Confirmed the blind spot first: with the test server live, `pgrep -f "http.server .*docs"` returns **no match**
- [x] Dry run of the new logic correctly partitions the two live servers — `WOULD KILL` the one with `cwd=<repo>/docs`, `would skip` an unrelated one at `cwd=/private/tmp/bbsmoke`
- [x] Live run: repo-rooted server killed, unrelated server on 8900 untouched
- [x] Re-ran with the snippet **extracted verbatim from `CLAUDE.md`** (`sed`'d out of the file and executed) rather than retyped, so the documented text is what was actually tested
- [x] `.claude/hooks/test-block-main-commit.sh` → PASS
- [x] `CLAUDE.md` 96 → 101 lines, 1505 → 1574 words

Docs-only change; `CLAUDE.md` is not rendered content, so no `docs/` rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)