### PR TITLE
docs: add a prose style guide for posts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,8 @@ done
 
 ## Writing conventions
 
+For blog posts, read and follow `notes/blog-style.md` before writing.
+
 **Give every post a spine.** A post is one argument, not a pile of sections. Name the core idea in a sentence before writing; every section advances it.
 
 - **Open on the core idea and the stakes** — the question, why it's non-obvious, what changes once the reader knows. No "in this post we will…" preamble.

--- a/notes/blog-style.md
+++ b/notes/blog-style.md
@@ -1,0 +1,56 @@
+# Blog Writing Style
+
+## Structure
+- Before any code block, diagram, or example, write 2–4 sentences of
+  plain-language warm-up: what problem this solves, why it matters, and
+  what the reader should understand before seeing the mechanics.
+- Never open a section with a code block, bullet list, or table. Give
+  context first, in prose.
+- Introduce a concept from first principles before naming its technical
+  term — explain the idea, then attach the label to it, not the other
+  way around.
+
+## Sentences and words
+- Prefer short, direct sentences. If a sentence has more than one
+  subordinate clause, split it.
+- Use everyday words over formal/Latinate ones where a simpler word
+  exists: "use" not "utilize," "help" not "facilitate," "start" not
+  "commence," "about" not "approximately."
+- Default to active voice ("the function returns X") over passive
+  ("X is returned by the function").
+- One idea per paragraph. If a paragraph covers two ideas, split it.
+
+## Tone
+- Write like you're explaining this to someone smart but unfamiliar
+  with the topic — not like documentation for someone who already
+  knows the shape of the solution.
+- Avoid jargon without a plain-language restatement nearby the first
+  time it's used.
+
+## Calibration examples
+
+Match this tone and pacing — motivate the problem, define the term
+plainly, then move to mechanics:
+
+**Example: cross-validation**
+A model can fit the data it was trained on almost perfectly and still
+fail on new data — this is the gap between memorizing and generalizing.
+Cross-validation is a way to estimate how a model will perform on unseen
+data using only the data you already have. The idea: split your dataset
+into k equal parts ("folds"). Train the model on k-1 of them, and test
+it on the one you held back. Repeat this k times, rotating which fold
+is held out, then average the results.
+
+**Example: the bootstrap**
+When you compute a statistic from a sample — a mean, a regression
+coefficient — you get one number, but you rarely know how much that
+number would vary if you'd drawn a different sample. The bootstrap
+estimates that variability without new data: it repeatedly draws new
+samples from your original sample, with replacement, and recomputes
+the statistic each time. The spread of those recomputed values
+approximates the sampling distribution you'd otherwise need new data
+to observe.
+
+Avoid: opening with opinion, meandering into the topic before defining
+it, assuming the reader already has context, or diving into code/examples
+before explaining the problem in plain language.


### PR DESCRIPTION
## Summary

- Posts have been reading wordy and hard to follow: they reach for code, diagrams and jargon before explaining in plain language what problem is being solved, and lean on long multi-clause sentences.
- Adds `notes/blog-style.md` — sentence- and paragraph-level rules (warm-up prose before mechanics, short sentences, active voice, everyday words over Latinate ones) plus two calibration examples (cross-validation, the bootstrap) that fix the target tone.
- `CLAUDE.md` gains a single pointer line under the existing `## Writing conventions`, so the always-loaded instructions stay short and the style rules can grow in their own file.

The guide lives in `notes/` rather than `docs/`: `docs/` is Quarto's `output-dir` and is deleted and rebuilt on a project render, while `_quarto.yml` already excludes `notes/` from rendering. The existing `## Writing conventions` rules are untouched — they cover post-level argument shape, the new file covers prose.

## Test plan

- [x] `make check-posts` passes — no post source touched, no freeze drift.
- [x] `git status` shows only `CLAUDE.md` and `notes/blog-style.md`; no `docs/` churn, so no re-render needed.
- [x] `grep -n 'notes/' _quarto.yml` confirms the `!notes/` render exclusion, so the guide is never published to the site.
- [ ] Not verified: whether the guide actually makes future posts less wordy — that shows up on the next post written against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)