### PR TITLE
docs: relocate and scope the blog style guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ done
 
 ## Writing conventions
 
-For blog posts, read and follow `STYLE.md` before writing.
+For blog posts, read and follow `STYLE.md` before writing or editing one.
 
 **Give every post a spine.** A post is one argument, not a pile of sections. Name the core idea in a sentence before writing; every section advances it.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ done
 
 ## Writing conventions
 
-For blog posts, read and follow `notes/blog-style.md` before writing.
+For blog posts, read and follow `STYLE.md` before writing.
 
 **Give every post a spine.** A post is one argument, not a pile of sections. Name the core idea in a sentence before writing; every section advances it.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ For blog posts, read and follow `STYLE.md` before writing.
 - **Open on the core idea and the stakes** — the question, why it's non-obvious, what changes once the reader knows. No "in this post we will…" preamble.
 - **Headings state claims, not topics** — `## Efron's bootstrap is a weighted bootstrap in disguise`, not `## Background`, so the ToC reconstructs the argument.
 - **Each section earns the next.** If two could swap without damage, merge or cut one. `###` is for steps within one idea, not new ideas.
-- **Stitch every seam.** A section's first sentence links back to the previous result or the core idea; its last names the unresolved thing the next section answers — the gap, not the mechanics ("next, some code"). Same for code and figures: a sentence before saying what it will show, one after saying what happened. If an opening sentence reads identically with the previous section deleted, the seam isn't stitched.
+- **Stitch every seam.** A section's first sentence links back to the previous result or the core idea; its last names the unresolved thing the next section answers — the gap, not the mechanics ("next, some code"). If an opening sentence reads identically with the previous section deleted, the seam isn't stitched.
 - **Close by returning to the core idea** — restate the opening claim now that it's earned, what it buys, where it stops holding. Not a summary of sections.
 - **Caveats inline**, as a short section where the objection occurs (`## Caveat: the uniform is the posterior, not the prior`) — not a "Limitations" bin at the end.
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,5 +1,23 @@
 # Blog Writing Style
 
+## Where these rules apply
+
+These rules govern new posts, and edits to posts that already carry their own
+venv, pinned kernel, and `requirements.txt`.
+
+They do **not** license a rewrite of the five legacy posts — `data-types`,
+`features-importance-after-clustering`, `poor-persons-bayesian`,
+`post-with-code`, `working-with-quarto` (the `LEGACY_NO_ENV` set in
+`scripts/check_posts.py`). Quarto keys frozen output on an md5 of the source,
+so even a one-word prose fix there invalidates the `_freeze/` record and makes
+the next project render try to execute a post that has no environment to
+execute in. To bring one of those up to this style, build it a venv + kernel +
+`requirements.txt` and drop its `LEGACY_NO_ENV` entry first, as CLAUDE.md
+describes.
+
+Nothing here is a mandate to sweep the existing corpus. Apply it to what you
+are already writing.
+
 ## Structure
 - Before any code block, diagram, or example, write 2–4 sentences of
   plain-language warm-up: what problem this solves, why it matters, and

--- a/STYLE.md
+++ b/STYLE.md
@@ -19,9 +19,18 @@ Nothing here is a mandate to sweep the existing corpus. Apply it to what you
 are already writing.
 
 ## Structure
-- Before any code block, diagram, or example, write 2–4 sentences of
-  plain-language warm-up: what problem this solves, why it matters, and
-  what the reader should understand before seeing the mechanics.
+- The first time a section reaches for a new idea, mechanism, or dataset,
+  write 2–4 sentences of plain-language warm-up before the code block,
+  diagram, or example: what problem this solves, why it matters, and what
+  the reader should hold in mind before seeing the mechanics.
+- Every *other* code block and figure keeps CLAUDE.md's seam rule instead —
+  one sentence before saying what it will show, one after saying what
+  happened. A follow-up cell, a variation on the last one, a plot of a
+  result already motivated: these get a sentence, not a paragraph. Padding
+  them out to a warm-up is a defect, not compliance.
+- The test between the two: could a reader predict what this block does
+  from the prose above it? If yes, one sentence is enough. If it turns a
+  corner they cannot see coming, warm them up first.
 - Never open a section with a code block, bullet list, or table. Give
   context first, in prose.
 - Introduce a concept from first principles before naming its technical
@@ -29,8 +38,16 @@ are already writing.
   way around.
 
 ## Sentences and words
-- Prefer short, direct sentences. If a sentence has more than one
-  subordinate clause, split it.
+- Prefer short, direct sentences. Split the ones that stack clauses until
+  the reader loses the subject before reaching the verb — two or more
+  nested subordinate clauses is the usual tell.
+- This is not a ban on the long sentence, and it is not a licence to
+  flatten the house voice. Clauses joined by em-dashes to gloss a term or
+  hang a concrete case off an abstract claim read as one clear beat; both
+  calibration examples below do it. Keep those. The target is the sentence
+  you have to read twice, not the sentence that is merely long.
+- Editing an existing post, match its register. These rules tighten prose;
+  they do not convert a post to a different voice.
 - Use everyday words over formal/Latinate ones where a simpler word
   exists: "use" not "utilize," "help" not "facilitate," "start" not
   "commence," "about" not "approximately."

--- a/STYLE.md
+++ b/STYLE.md
@@ -2,8 +2,7 @@
 
 ## Where these rules apply
 
-These rules govern new posts, and edits to posts that already carry their own
-venv, pinned kernel, and `requirements.txt`.
+These rules govern new posts and edits to existing ones, with one exception.
 
 They do **not** license a rewrite of the five legacy posts — `data-types`,
 `features-importance-after-clustering`, `poor-persons-bayesian`,

--- a/STYLE.md
+++ b/STYLE.md
@@ -23,14 +23,10 @@ are already writing.
   write 2–4 sentences of plain-language warm-up before the code block,
   diagram, or example: what problem this solves, why it matters, and what
   the reader should hold in mind before seeing the mechanics.
-- Every *other* code block and figure keeps CLAUDE.md's seam rule instead —
-  one sentence before saying what it will show, one after saying what
-  happened. A follow-up cell, a variation on the last one, a plot of a
-  result already motivated: these get a sentence, not a paragraph. Padding
-  them out to a warm-up is a defect, not compliance.
-- The test between the two: could a reader predict what this block does
-  from the prose above it? If yes, one sentence is enough. If it turns a
-  corner they cannot see coming, warm them up first.
+- After that, one sentence before and one after carries it — a follow-up
+  cell, a variation on the last one, a plot of a result you already
+  motivated. If a reader can predict what the block does from the prose
+  above it, one sentence is the right amount.
 - Never open a section with a code block, bullet list, or table. Give
   context first, in prose.
 - Introduce a concept from first principles before naming its technical


### PR DESCRIPTION
## Summary

Follow-up to #163, addressing the four findings its review raised.

- **Moved `notes/blog-style.md` → `STYLE.md`** at the repo root. `notes/` is documented in `CLAUDE.md` as "a scratch area, not published content", so a normative guide living there was one cleanup away from deleting itself and leaving the CLAUDE.md pointer dangling. The root is not scratch, and `STYLE.md` is still not rendered — `_quarto.yml` globs only `*.qmd`/`*.ipynb`. The now-empty `notes/` directory is gone, so CLAUDE.md's description of it is accurate again.
- **Scoped the guide off the legacy posts.** A new `## Where these rules apply` section states that the rules govern new posts and posts that already carry a venv + kernel + `requirements.txt`, and explicitly do not license rewriting the five `LEGACY_NO_ENV` posts — any prose edit there invalidates the md5-keyed `_freeze/` record and makes the next project render try to execute a post with no environment.
- **Deduplicated the code/figure rule.** `CLAUDE.md` and the guide both said how much prose a code block is owed, and disagreed (2–4 sentences of warm-up vs. one sentence before and after). Rather than rank them, `CLAUDE.md` gives up its code/figure sentence and keeps the section-seam rule; `STYLE.md` is now the sole authority and states the graded rule directly — warm-up on the first reach for a new idea, one sentence for routine blocks after that.
- **Stopped the sentence rule from flattening the house voice.** "Split anything with more than one subordinate clause" would have rewritten a corpus built on em-dash-joined sentences. It now targets the sentence you have to read twice, keeps em-dash glosses, and yields to an existing post's register.

Net effect on `CLAUDE.md`: one pointer line in (#163), one sentence out — 17,540 bytes vs 17,654 on `main`.

## Test plan

- [x] `make check-posts` passes — no post source touched, no `_freeze/` drift.
- [x] `git diff main --stat` shows only `CLAUDE.md` and the `notes/blog-style.md → STYLE.md` rename; no `docs/` churn, so no re-render needed.
- [x] `grep -n 'blog-style'` finds no surviving reference to the old path outside built `docs/`.
- [x] `_quarto.yml` render globs confirmed to exclude root markdown, so `STYLE.md` is not published to the site.
- [ ] Not verified: whether the guide actually makes future posts less wordy — that shows up on the next post written against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)